### PR TITLE
GitHub Actions에서 `.env` 파일 생성 오류 수정 (#16)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,14 @@ jobs:
         - uses: subosito/flutter-action@v2
           with:
             channel: 'stable'
+        - name: Create .env file from secrets
+          run: |
+            cat <<EOF > .env
+            RECORD_PRESET_URL="${{ secrets.RECORD_PRESET_URL }}"
+            RECORDER_MOD_URL="${{ secrets.RECORDER_MOD_URL }}"
+            SUPABASE_URL="${{ secrets.SUPABASE_URL }}"
+            SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}"
+            EOF
         - run: flutter build windows
         - name: Upload Build Artifact
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,12 @@ jobs:
         - uses: subosito/flutter-action@v2
           with:
             channel: 'stable'
-        - name: Create .env file from secrets
+        - name: Generate .env file
           run: |
-            cat <<EOF > .env
-            RECORD_PRESET_URL="${{ secrets.RECORD_PRESET_URL }}"
-            RECORDER_MOD_URL="${{ secrets.RECORDER_MOD_URL }}"
-            SUPABASE_URL="${{ secrets.SUPABASE_URL }}"
-            SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}"
-            EOF
+            Set-Content .env "RECORD_PRESET_URL=`"${{ secrets.RECORD_PRESET_URL }}`""
+            Add-Content .env "RECORDER_MOD_URL=`"${{ secrets.RECORDER_MOD_URL }}`""
+            Add-Content .env "SUPABASE_URL=`"${{ secrets.SUPABASE_URL }}`""
+            Add-Content .env "SUPABASE_ANON_KEY=`"${{ secrets.SUPABASE_ANON_KEY }}`""
         - run: flutter build windows
         - name: Upload Build Artifact
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 개요

- GitHub Actions에서 `.env` 파일이 없어서 발생하던 빌드 실패 문제를 수정하였습니다.
- `.env` 파일을 생성한 뒤 빌드하도록 `main.yml`을 수정하였으며, 필요한 환경변수는 GitHub Secrets에 등록해야 합니다.
- 본 PR은 #16 이슈에 대한 해결입니다.

## 주요 변경 사항

- `.env` 파일을 생성하는 step 추가
- GitHub Secrets를 통해 다음 환경변수 값 주입:
  - `RECORD_PRESET_URL`
  - `RECORDER_MOD_URL`
  - `SUPABASE_URL`
  - `SUPABASE_ANON_KEY`

## GitHub Secrets 등록 방법

> 아래 환경변수는 GitHub Repository → `Settings > Secrets and variables > Actions` 메뉴에서 `Repository secrets`에 각각 등록해야 합니다:

* `RECORD_PRESET_URL` 
* `RECORDER_MOD_URL`
* `SUPABASE_URL` 
* `SUPABASE_ANON_KEY`

`.env`에 추가 내용이 있다면 **pull request** 내용을 수정하세요.

## 관련 이슈

#16
