### PR TITLE
후원링크, 오픈카톡링크 변경 (#18)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,14 @@ jobs:
         - uses: subosito/flutter-action@v2
           with:
             channel: 'stable'
+        - name: Create .env file from secrets
+          run: |
+            cat <<EOF > .env
+            RECORD_PRESET_URL="${{ secrets.RECORD_PRESET_URL }}"
+            RECORDER_MOD_URL="${{ secrets.RECORDER_MOD_URL }}"
+            SUPABASE_URL="${{ secrets.SUPABASE_URL }}"
+            SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}"
+            EOF
         - run: flutter build windows
         - name: Upload Build Artifact
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,12 @@ jobs:
         - uses: subosito/flutter-action@v2
           with:
             channel: 'stable'
-        - name: Create .env file from secrets
+        - name: Generate .env file
           run: |
-            cat <<EOF > .env
-            RECORD_PRESET_URL="${{ secrets.RECORD_PRESET_URL }}"
-            RECORDER_MOD_URL="${{ secrets.RECORDER_MOD_URL }}"
-            SUPABASE_URL="${{ secrets.SUPABASE_URL }}"
-            SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}"
-            EOF
+            Set-Content .env "RECORD_PRESET_URL=`"${{ secrets.RECORD_PRESET_URL }}`""
+            Add-Content .env "RECORDER_MOD_URL=`"${{ secrets.RECORDER_MOD_URL }}`""
+            Add-Content .env "SUPABASE_URL=`"${{ secrets.SUPABASE_URL }}`""
+            Add-Content .env "SUPABASE_ANON_KEY=`"${{ secrets.SUPABASE_ANON_KEY }}`""
         - run: flutter build windows
         - name: Upload Build Artifact
           uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -3,5 +3,35 @@
 
 The Binding of Isaac: Repentance를 위한 모드 프리셋 저장 유틸리티입니다.
 
+---
+
 ## 참고
-이 소프트웨어는 방송인 오헌영([유튜브](https://www.youtube.com/@HeonYeong_Isaac), [트위치](https://www.twitch.tv/iwt2hw))님을 위해 제작되었습니다. 일반 사용자에게 불필요한 기능이 있을 수 있습니다.
+
+이 프로그램은 방송인 **오헌영**님을 위해 개발되었습니다. 일반 사용자에게는 다소 특화된 기능이 포함되어 있을 수 있습니다.
+
+- [유튜브 채널](https://www.youtube.com/@아이작오헌영)
+- [트위치 방송](https://www.twitch.tv/iwt2hw)
+- [아프리카TV](https://bj.afreecatv.com/iwt2hw)
+- [치지직](https://chzzk.naver.com/f409bd9619bb9d384159a82d8892f73a)
+
+---
+
+## 설치
+
+[최신 버전](https://github.com/TeamHY/cartridge/releases/latest)은 GitHub Release 페이지를 통해 제공합니다.
+
+---
+
+## 기능
+
+- 다양한 모드 조합을 **프리셋**으로 저장 및 불러오기
+- 도전 모드용 기록 기능 (랭킹 포함)
+- 방송용 **슬롯 머신** UI 기능
+
+---
+
+## 커뮤니티 링크
+
+- [네이버 카페](https://cafe.naver.com/iwt2hw)
+- [오픈 카카오톡](https://open.kakao.com/o/gXkuZvze)
+- [디스코드](https://discord.gg/MrJ94bekzU)

--- a/lib/constants/urls.dart
+++ b/lib/constants/urls.dart
@@ -1,0 +1,31 @@
+class AppUrls {
+  // GitHub
+  static const githubRepo = 'https://github.com/TeamHY/cartridge';
+  static const githubLatestRelease = '$githubRepo/releases/latest';
+  static const githubApiLatestRelease =
+      'https://api.github.com/repos/TeamHY/cartridge/releases/latest';
+
+  // 오헌영 방송 채널
+  static const youtube = 'https://www.youtube.com/@아이작오헌영'; // 변경되면 README.md도 수정하기
+  static const twitch = 'https://www.twitch.tv/iwt2hw'; // 변경되면 README.md도 수정하기
+  static const afreeca = 'https://bj.afreecatv.com/iwt2hw';
+  static const chzzk = 'https://chzzk.naver.com/f409bd9619bb9d384159a82d8892f73a';
+
+  // 커뮤니티
+  static const openChat = 'https://open.kakao.com/o/gXkuZvze';
+  static const discord = 'https://discord.gg/MrJ94bekzU';
+
+  // 후원
+  static const donationPlaysquad = 'https://pls.gg/iwt2hw'; // playsquad 후원
+  static const donation = 'https://ohy.kr/toon'; // toonation 후원
+
+  // 네이버 카페 게시물
+  static const naverCafeHome = 'https://cafe.naver.com/iwt2hw';
+  static const manualUpdatePost = '$naverCafeHome/128';
+  static const rulesPost = '$naverCafeHome/4478';
+  static const modsPost = '$naverCafeHome/2';
+
+  // 스팀
+  static const steamAstrobirthPatchNotes =
+      'https://steamcommunity.com/sharedfiles/filedetails/changelog/2492350811';
+}

--- a/lib/widgets/pages/battle_page.dart
+++ b/lib/widgets/pages/battle_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:http/http.dart' as http;
+import 'package:cartridge/constants/urls.dart';
 
 class BattlePage extends ConsumerStatefulWidget {
   const BattlePage({super.key});
@@ -289,9 +290,7 @@ class QuickAction extends StatelessWidget {
             ),
           ),
           onPressed: () => launchUrl(
-            Uri.parse(
-              'https://cafe.naver.com/iwt2hw/128',
-            ),
+            Uri.parse(AppUrls.manualUpdatePost),
           ),
         ),
         HyperlinkButton(
@@ -305,9 +304,7 @@ class QuickAction extends StatelessWidget {
             ),
           ),
           onPressed: () => launchUrl(
-            Uri.parse(
-              'https://steamcommunity.com/sharedfiles/filedetails/changelog/2492350811',
-            ),
+            Uri.parse(AppUrls.steamAstrobirthPatchNotes),
           ),
         ),
       ],

--- a/lib/widgets/pages/home_page.dart
+++ b/lib/widgets/pages/home_page.dart
@@ -18,6 +18,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:http/http.dart' as http;
+import 'package:cartridge/constants/urls.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -31,9 +32,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   late TextEditingController _searchController;
 
   void checkAppVersion() async {
-    final response = await http.get(Uri.parse(
-      'https://api.github.com/repos/TeamHY/cartridge/releases/latest',
-    ));
+    final response = await http.get(Uri.parse(AppUrls.githubApiLatestRelease));
 
     if (response.statusCode != 200) {
       return;
@@ -51,8 +50,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             actions: [
               FilledButton(
                 onPressed: () async {
-                  await launchUrl(Uri.parse(
-                      'https://github.com/TeamHY/cartridge/releases/latest'));
+                  await launchUrl(Uri.parse(AppUrls.githubLatestRelease));
                   exit(0);
                 },
                 child: const Text('확인'),
@@ -75,8 +73,7 @@ class _HomePageState extends ConsumerState<HomePage> {
               ),
               FilledButton(
                 onPressed: () {
-                  launchUrl(Uri.parse(
-                      'https://github.com/TeamHY/cartridge/releases/latest'));
+                  launchUrl(Uri.parse(AppUrls.githubLatestRelease));
                   Navigator.pop(context);
                 },
                 child: const Text('확인'),

--- a/lib/widgets/pages/record_page.dart
+++ b/lib/widgets/pages/record_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cartridge/constants/urls.dart';
 import 'package:cartridge/models/daily_challenge.dart';
 import 'package:cartridge/models/mod.dart';
 import 'package:cartridge/models/preset.dart';
@@ -495,7 +496,7 @@ class _RecordPageState extends ConsumerState<RecordPage> with WindowListener {
                 ),
                 onPressed: () async {
                   await launchUrl(
-                      Uri.parse('https://cafe.naver.com/iwt2hw/4478'));
+                      Uri.parse(AppUrls.rulesPost));
                 },
               ),
               const SizedBox(height: 32),

--- a/lib/widgets/quick_bar.dart
+++ b/lib/widgets/quick_bar.dart
@@ -1,3 +1,4 @@
+import 'package:cartridge/constants/urls.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -13,26 +14,25 @@ class QuickBar extends StatelessWidget {
       children: [
         Button(
             onPressed: () async {
-              await launchUrl(Uri.parse('https://www.youtube.com/@아이작오헌영'));
-              await launchUrl(Uri.parse('https://www.twitch.tv/iwt2hw'));
-              await launchUrl(Uri.parse('https://bj.afreecatv.com/iwt2hw'));
-              await launchUrl(Uri.parse(
-                  'https://chzzk.naver.com/f409bd9619bb9d384159a82d8892f73a'));
+              await launchUrl(Uri.parse(AppUrls.youtube));
+              await launchUrl(Uri.parse(AppUrls.twitch));
+              await launchUrl(Uri.parse(AppUrls.afreeca));
+              await launchUrl(Uri.parse(AppUrls.chzzk));
             },
             child: const Text('생방송')),
         const SizedBox(width: 4),
         Button(
             onPressed: () =>
-                launchUrl(Uri.parse('https://open.kakao.com/o/gFr6pCbf')),
+                launchUrl(Uri.parse(AppUrls.openChat)),
             child: const Text('오픈채팅')),
         const SizedBox(width: 4),
         Button(
             onPressed: () =>
-                launchUrl(Uri.parse('https://cafe.naver.com/iwt2hw/2')),
+                launchUrl(Uri.parse(AppUrls.modsPost)),
             child: const Text('모드')),
         const SizedBox(width: 4),
         Button(
-            onPressed: () => launchUrl(Uri.parse('https://toss.me/iwt2hw')),
+            onPressed: () => launchUrl(Uri.parse(AppUrls.donation)),
             child: const Text('후원')),
       ],
     );


### PR DESCRIPTION
## 개요

- URL들을 중앙 집중식으로 관리하기 위해 `AppUrls` 상수 클래스로 리팩토링하였습니다.
- 이 과정에서 사용되지 않거나 만료된 링크(예: 토스, 구 오픈카톡 링크)를 교체하고, `README.md`도 최신화하였습니다.
- 본 PR은 #18 이슈에 대한 해결 및 리팩토링 PR입니다.

---

## 주요 변경 사항

### URL 상수화 및 리팩토링
- `lib/constants/urls.dart` 생성
- 앱 전역에서 사용하는 외부 URL을 `AppUrls` 클래스로 통합 관리
- 모든 위젯 내 URL 하드코딩 제거 → `AppUrls` 참조로 변경

### 링크 업데이트
- 오픈 카톡: `https://open.kakao.com/o/gXkuZvze`
- 후원 링크
  - Toonaton: `https://ohy.kr/toon` -  버튼 클릭 시 연결된 링크
  - Playsquad: `https://pls.gg/iwt2hw`

### README.md 수정
- 유튜브 링크 최신화

---

## 비고

- 코드 리팩토링 범위는 단순한 URL 관리 통합에 국한되며, 기능상 동작 변화는 없습니다.
- 추후 링크 변경이 발생해도 `urls.dart` 하나만 수정하면 되도록 구조화했습니다.
- Github Action 성공을 위해 #17 PR 내용을 포함하고 있습니다.
